### PR TITLE
Add max-nondet-tree-depth to diffblue.yml

### DIFF
--- a/diffblue.yml
+++ b/diffblue.yml
@@ -8,12 +8,14 @@ phases:
     classpath: '/tools/cbmc/models-simple-overlay.jar:/tools/cbmc/models.jar:.'
     java-assume-inputs-non-null: true
     max-nondet-array-length: 10
+    max-nondet-tree-depth: 10
     unwind: 1
 -
   timeout: 300
   cbmcArguments:
     classpath: '/tools/cbmc/models-simple-overlay.jar:/tools/cbmc/models.jar:.'
     max-nondet-array-length: 20
+    max-nondet-tree-depth: 10
     unwind: 2
 -
   timeout: 300


### PR DESCRIPTION
In phases 1 & 2, limit the nondet tree depth (dereferencing depth) to 10, to override the test-gen default 5.