### PR TITLE
max-nondet-array-length 100 on all phases

### DIFF
--- a/diffblue.yml
+++ b/diffblue.yml
@@ -7,21 +7,20 @@ phases:
   cbmcArguments:
     classpath: '/tools/cbmc/models-simple-overlay.jar:/tools/cbmc/models.jar:.'
     java-assume-inputs-non-null: true
-    max-nondet-array-length: 10
+    max-nondet-array-length: 100
     java-max-vla-length: 4097
     unwind: 1
 -
   timeout: 300
   cbmcArguments:
     classpath: '/tools/cbmc/models-simple-overlay.jar:/tools/cbmc/models.jar:.'
-    max-nondet-array-length: 20
+    max-nondet-array-length: 100
     java-max-vla-length: 4097
     unwind: 2
 -
   timeout: 300
   cbmcArguments:
     classpath: '/tools/cbmc/models.jar:.'
-    max-nondet-array-length: 30
-    max-nondet-string-length: 10
+    max-nondet-array-length: 100
     java-max-vla-length: 4097
     unwind: 3


### PR DESCRIPTION
`max-nondet-array-length` has little impact on runtime, and having a value below 50 gives UNSAT on many methods.
Also adapted `max-nondet-string-length` that has little effect on runtime.