### PR TITLE
Remove assume-inputs-non-null

### DIFF
--- a/diffblue.yml
+++ b/diffblue.yml
@@ -6,7 +6,6 @@ phases:
   timeout: 300
   cbmcArguments:
     classpath: '/tools/cbmc/models-simple-overlay.jar:/tools/cbmc/models.jar:.'
-    java-assume-inputs-non-null: true
     max-nondet-array-length: 100
     java-max-vla-length: 4097
     unwind: 1


### PR DESCRIPTION
Some coverage is lost because of this option.
We should only be using this if we have a following stage that can cover the missing goals. The unwind values are too different to ensure that in the current configuration.