### PR TITLE
Correct typo in diffblue.yml

### DIFF
--- a/diffblue.yml
+++ b/diffblue.yml
@@ -1,7 +1,7 @@
 cbmcArguments:
   depth: false
   java-external-code-action: 'mock'
-  load-containing-class-only: 'true'
+  load-containing-class-only: true
 phases:
 -
   timeout: 300


### PR DESCRIPTION
Boolean statements don't take quotes.